### PR TITLE
createGameの実装

### DIFF
--- a/docs/db_schema.md
+++ b/docs/db_schema.md
@@ -13,12 +13,11 @@
 
 ## `waiting_players`
 
-| 列名       | 型            | 制約                             | 既定値 | 説明           |
-| ---------- | ------------- | -------------------------------- | ------ | -------------- |
-| id         | `INT`         | **PK**, **AUTO_INCREMENT**       | ―      | 行連番         |
-| user_name  | `VARCHAR(32)` | **PK**, **UNIQUE**, **NOT NULL** | ―      | 参加ユーザー   |
-| waiting    | `BOOLEAN`     | **NOT NULL**                     | `TRUE` | 待機中かどうか |
-| created_at | `DATETIME`    | **NOT NULL**                     | ―      | 作成時刻       |
+| 列名       | 型            | 制約                             | 既定値 | 説明         |
+| ---------- | ------------- | -------------------------------- | ------ | ------------ |
+| id         | `INT`         | **PK**, **AUTO_INCREMENT**       | ―      | 行連番       |
+| user_name  | `VARCHAR(32)` | **PK**, **UNIQUE**, **NOT NULL** | ―      | 参加ユーザー |
+| created_at | `DATETIME`    | **NOT NULL**                     | ―      | 作成時刻     |
 
 ## `game_players`
 

--- a/server/internal/core/coredb/error.go
+++ b/server/internal/core/coredb/error.go
@@ -2,5 +2,8 @@ package coredb
 
 import "errors"
 
-var ErrRecordNotFound = errors.New("not found")
-var ErrNoRecordUpdated = errors.New("no record updated")
+var (
+	ErrRecordNotFound  = errors.New("not found")
+	ErrNoRecordUpdated = errors.New("no record updated")
+	ErrDuplicateKey    = errors.New("duplicate key")
+)

--- a/server/internal/games/create.go
+++ b/server/internal/games/create.go
@@ -1,0 +1,24 @@
+package games
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/traP-jp/h25s_15/internal/users"
+)
+
+func (h *Handler) CreateGame(c echo.Context) error {
+	userName, err := users.GetUserName(c)
+	if err != nil {
+		c.Logger().Errorf("failed to get user name: %v", err)
+		return echo.NewHTTPError(http.StatusInternalServerError)
+	}
+
+	err = h.repo.CreateWaitingPlayer(c.Request().Context(), userName)
+	if err != nil {
+		c.Logger().Errorf("failed to create waiting player: %v", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to create waiting player")
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}

--- a/server/internal/games/create.go
+++ b/server/internal/games/create.go
@@ -1,9 +1,11 @@
 package games
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/traP-jp/h25s_15/internal/core/coredb"
 	"github.com/traP-jp/h25s_15/internal/users"
 )
 
@@ -15,9 +17,12 @@ func (h *Handler) CreateGame(c echo.Context) error {
 	}
 
 	err = h.repo.CreateWaitingPlayer(c.Request().Context(), userName)
+	if errors.Is(err, coredb.ErrDuplicateKey) {
+		return echo.NewHTTPError(http.StatusBadRequest, "player already waiting")
+	}
 	if err != nil {
 		c.Logger().Errorf("failed to create waiting player: %v", err)
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to create waiting player")
+		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/server/internal/games/internal/repository/repository.go
+++ b/server/internal/games/internal/repository/repository.go
@@ -14,4 +14,7 @@ type Repo interface {
 
 	// GetPlayers は、該当するgameIDのプレイヤー情報を取得する。
 	GetPlayers(ctx context.Context, gameID uuid.UUID) ([]domain.Player, error)
+
+	// CreateWaitingPlayer は、指定されたユーザー名で待機中のプレイヤーを作成する。
+	CreateWaitingPlayer(ctx context.Context, userName string) error
 }

--- a/server/internal/games/internal/repository/repository.go
+++ b/server/internal/games/internal/repository/repository.go
@@ -16,5 +16,6 @@ type Repo interface {
 	GetPlayers(ctx context.Context, gameID uuid.UUID) ([]domain.Player, error)
 
 	// CreateWaitingPlayer は、指定されたユーザー名で待機中のプレイヤーを作成する。
+	// 既に待機中のプレイヤーが存在する場合は、coredb.ErrDuplicateKeyを返す。
 	CreateWaitingPlayer(ctx context.Context, userName string) error
 }

--- a/server/internal/sql/1_drop_waiting_column.sql
+++ b/server/internal/sql/1_drop_waiting_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE waiting_players
+DROP COLUMN waiting;

--- a/server/main.go
+++ b/server/main.go
@@ -34,6 +34,7 @@ func main() {
 	userApi.GET("/me", user.GetMe)
 
 	gameApi := e.Group("/games")
+	gameApi.POST("", game.CreateGame)
 	gameApi.GET("/:gameID/ws", game.GameWS)
 
 	e.POST("/games/:gameID/clear", card.ClearHandCards,


### PR DESCRIPTION
fix #38

- **:boom: waiting_playersテーブルの変更**
- **:sparkles: createGameのハンドラー実装**
- **:adhesive_bandage: ErrDuplicateKeyを返すようにする**
- **:sparkles: repositoryのCreateWaitingPlayerメソッドを追加**
- **:sparkles: ハンドラーの登録**
