### PR TITLE
field_cards_limitsテーブルの初期化

### DIFF
--- a/server/internal/games/internal/repository/db/field_limit.go
+++ b/server/internal/games/internal/repository/db/field_limit.go
@@ -1,0 +1,23 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+const initialFieldCardsLimit int = 4
+
+func (r *Repo) InitializeFieldCardsLimit(ctx context.Context, gameID uuid.UUID) error {
+	_, err := r.db.DB(ctx).ExecContext(ctx, `
+		UPDATE field_cards
+		SET limit = ?
+		WHERE game_id = ?
+	`, initialFieldCardsLimit, gameID)
+	if err != nil {
+		return fmt.Errorf("initialize field cards limit: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/games/internal/repository/db/field_limit.go
+++ b/server/internal/games/internal/repository/db/field_limit.go
@@ -10,11 +10,8 @@ import (
 const initialFieldCardsLimit int = 4
 
 func (r *Repo) InitializeFieldCardsLimit(ctx context.Context, gameID uuid.UUID) error {
-	_, err := r.db.DB(ctx).ExecContext(ctx, `
-		UPDATE field_cards_limits
-		SET field_cards = ?
-		WHERE game_id = ?
-	`, initialFieldCardsLimit, gameID)
+	_, err := r.db.DB(ctx).ExecContext(ctx, "INSERT INTO field_cards_limits (game_id, field_cards) VALUES (?, ?)",
+		gameID, initialFieldCardsLimit)
 	if err != nil {
 		return fmt.Errorf("initialize field cards limit: %w", err)
 	}

--- a/server/internal/games/internal/repository/db/field_limit.go
+++ b/server/internal/games/internal/repository/db/field_limit.go
@@ -11,8 +11,8 @@ const initialFieldCardsLimit int = 4
 
 func (r *Repo) InitializeFieldCardsLimit(ctx context.Context, gameID uuid.UUID) error {
 	_, err := r.db.DB(ctx).ExecContext(ctx, `
-		UPDATE field_cards
-		SET limit = ?
+		UPDATE field_cards_limits
+		SET field_cards = ?
 		WHERE game_id = ?
 	`, initialFieldCardsLimit, gameID)
 	if err != nil {

--- a/server/internal/games/internal/repository/repository.go
+++ b/server/internal/games/internal/repository/repository.go
@@ -42,6 +42,9 @@ type Repo interface {
 	// InitializeHandLimit は、指定されたゲームIDのプレイヤーのhand cardsの制限を初期化する。
 	InitializeHandLimit(ctx context.Context, gameID uuid.UUID) error
 
+	// InitializeFieldCardsLimit は、指定されたゲームIDのフィールドカードの制限を初期化する。
+	InitializeFieldCardsLimit(ctx context.Context, gameID uuid.UUID) error
+
 	// StartGame は、指定されたゲームIDのゲームを開始する。
 	StartGame(ctx context.Context, gameID uuid.UUID, startAt time.Time) error
 }

--- a/server/internal/games/prepare.go
+++ b/server/internal/games/prepare.go
@@ -14,7 +14,12 @@ func (h *Handler) PrepareGame(ctx context.Context, gameID uuid.UUID) error {
 
 		// TODO: fieldCardsを作って登録する
 
-		err := h.repo.InitializeHandLimit(ctx, gameID)
+		err := h.repo.InitializeFieldCardsLimit(ctx, gameID)
+		if err != nil {
+			return fmt.Errorf("initialize field cards limit: %w", err)
+		}
+
+		err = h.repo.InitializeHandLimit(ctx, gameID)
 		if err != nil {
 			return fmt.Errorf("initialize hand limit: %w", err)
 		}


### PR DESCRIPTION
fix #102

- **:sparkles: repositoryでInitializeFieldCardsLimitを追加**
- **:sparkles: prepareでFieldCardsLimitを設定する**
- **:bug: SQLの修正**
- **:bug: SQL修正**
