### PR TITLE
docs: `gameStarted`イベントペイロードに`turnTotal`を追加

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -102,6 +102,7 @@ operationID: `gameWS`
   "type": "gameStarted",
   "currentPlayerId": 0,
   "turn": 1,
+  "turnTotal": 10
 }
 ```
 


### PR DESCRIPTION
close #117 

"ターン数の合計"なので`nextTurn`等と混同しないように`turnTotal`としました