### PR TITLE
gameEndedイベントの実装

### DIFF
--- a/server/internal/games/end.go
+++ b/server/internal/games/end.go
@@ -1,0 +1,52 @@
+package games
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/traP-jp/h25s_15/internal/games/internal/events"
+)
+
+func (h *Handler) EndGame(ctx context.Context, gameID uuid.UUID, endAt time.Time) error {
+	err := h.db.Transaction(ctx, func(ctx context.Context) error {
+		err := h.repo.EndGame(ctx, gameID, endAt)
+		if err != nil {
+			return fmt.Errorf("end game: %w", err)
+		}
+
+		players, err := h.repo.GetPlayers(ctx, gameID)
+		if err != nil {
+			return fmt.Errorf("get players: %w", err)
+		}
+
+		var score0, score1 int
+		for _, player := range players {
+			switch player.PlayerID {
+			case 0:
+				score0 = player.Score
+			case 1:
+				score1 = player.Score
+			default:
+				return fmt.Errorf("unexpected player ID: %d", player.PlayerID)
+			}
+		}
+
+		err = h.events.GameEnded(ctx, gameID, events.GameEndedEvent{
+			Type:    "gameEnded",
+			Player0: score0,
+			Player1: score1,
+		})
+		if err != nil {
+			return fmt.Errorf("send game ended event: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("end game transaction: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/games/internal/events/events.go
+++ b/server/internal/games/internal/events/events.go
@@ -64,6 +64,12 @@ type TurnTimeRemainingChangedEvent struct {
 	RemainingSeconds int    `json:"remainingSeconds"` // Remaining time for the turn in seconds
 }
 
+type GameEndedEvent struct {
+	Type    string `json:"type"`
+	Player0 int    `json:"player0"` // Score of player 0
+	Player1 int    `json:"player1"` // Score of player 1
+}
+
 type Event interface {
 	HandleRequestWithKeys(res http.ResponseWriter, req *http.Request, keys map[string]any)
 	GetConnectedWaitingUsers(ctx context.Context) ([]string, error)
@@ -78,4 +84,5 @@ type Event interface {
 	TurnStarted(ctx context.Context, gameID uuid.UUID, event TurnStartedEvent) error
 	TurnEnded(ctx context.Context, gameID uuid.UUID, event TurnEndedEvent) error
 	TurnTimeRemainingChanged(ctx context.Context, gameID uuid.UUID, event TurnTimeRemainingChangedEvent) error
+	GameEnded(ctx context.Context, gameID uuid.UUID, event GameEndedEvent) error
 }

--- a/server/internal/games/internal/events/ws/game_ended.go
+++ b/server/internal/games/internal/events/ws/game_ended.go
@@ -1,0 +1,24 @@
+package ws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/traP-jp/h25s_15/internal/core/corews"
+	"github.com/traP-jp/h25s_15/internal/games/internal/events"
+)
+
+func (e *Event) GameEnded(ctx context.Context, gameID uuid.UUID, event events.GameEndedEvent) error {
+	eventJSON, err := corews.JSON(event)
+	if err != nil {
+		return fmt.Errorf("marshal game ended event: %w", err)
+	}
+
+	err = e.m.BroadcastBinaryFilter(eventJSON, corews.FilterGameID(gameID))
+	if err != nil {
+		return fmt.Errorf("broadcast game ended event: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/games/internal/repository/db/db.go
+++ b/server/internal/games/internal/repository/db/db.go
@@ -266,3 +266,21 @@ func (r *Repo) GetTurn(ctx context.Context, gameID uuid.UUID) (domain.Turn, erro
 		EndAt:      turn.EndAt,
 	}, nil
 }
+
+func (r *Repo) EndGame(ctx context.Context, gameID uuid.UUID, endAt time.Time) error {
+	result, err := r.db.DB(ctx).ExecContext(ctx,
+		"UPDATE games SET status = ?, ended_at = ? WHERE id = ?",
+		domain.GameStatusFinished, sql.NullTime{Time: endAt, Valid: true}, gameID,
+	)
+	if err != nil {
+		return fmt.Errorf("end game: %w", err)
+	}
+
+	if rowsAffected, err := result.RowsAffected(); err != nil {
+		return fmt.Errorf("get rows affected: %w", err)
+	} else if rowsAffected == 0 {
+		return coredb.ErrRecordNotFound
+	}
+
+	return nil
+}

--- a/server/internal/games/internal/repository/repository.go
+++ b/server/internal/games/internal/repository/repository.go
@@ -53,6 +53,9 @@ type Repo interface {
 
 	// GetTurn は、指定されたゲームIDの最新のターン情報を取得する。
 	GetTurn(ctx context.Context, gameID uuid.UUID) (domain.Turn, error)
+
+	// EndGame は、指定されたゲームIDのゲームを終了する。
+	EndGame(ctx context.Context, gameID uuid.UUID, endAt time.Time) error
 }
 
 type CreatePlayersArg struct {

--- a/server/internal/games/ws.go
+++ b/server/internal/games/ws.go
@@ -84,6 +84,14 @@ func (h *Handler) GameWS(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
 
+		time.Sleep(time.Second) // 変更が確実にDBに保存されるまで待つ
+
+		err = h.EndGame(ctx, gameID, time.Now())
+		if err != nil {
+			c.Logger().Errorf("failed to end game %s: %v", gameID, err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+
 		return nil
 	})
 


### PR DESCRIPTION
fix #49

- **:sparkles: gameEndedのイベント実装**
- **:sparkles: wsのGameEndedイベントを実装**
- **:sparkles: repositoryのEndGameメソッドを実装**
- **:sparkles: wsのハンドラーに組み込む**
