### PR TITLE
chore: ターンの制限時間を`GameInfo`で保持するように変更

### DIFF
--- a/client/src/lib/gameLogic.ts
+++ b/client/src/lib/gameLogic.ts
@@ -24,6 +24,8 @@ export class GameInfo {
   turn: number
   turnTimeRemaining: number
 
+  currentTurnTimeLimit: number
+
   constructor(gameId: string) {
     this.gameId = gameId
     this.myPlayerId = 0
@@ -35,6 +37,7 @@ export class GameInfo {
     this.currentPlayerId = -1
     this.turn = 0
     this.turnTimeRemaining = 0
+    this.currentTurnTimeLimit = 0
   }
 
   useCard(cardId: string): void {
@@ -116,6 +119,7 @@ export class GameInfo {
     this.currentPlayerId = event.currentPlayerId
     this.turn = event.turn
     this.turnTimeRemaining = event.turnTimeRemaining
+    this.currentTurnTimeLimit = event.turnTimeRemaining
   }
 
   private handleCardsUpdated(event: CardsUpdated): void {
@@ -151,6 +155,7 @@ export class GameInfo {
   private handleTurnEnded(event: TurnEnded): void {
     this.currentPlayerId = event.nextPlayerId
     this.turn = event.nextTurn ?? this.turn + 1
+    this.turnTimeRemaining = 0
   }
 
   private handleGameEnded(event: GameEnded): void {


### PR DESCRIPTION
close #133 

制限時間の変化については、アイテムの使用を陽に検知するのが難しそうだったので次ターンからの反映になっています